### PR TITLE
complete rewrite of the event system in MCW 3

### DIFF
--- a/system/modules/multicolumnwizard/html/js/multicolumnwizard_be_src.js
+++ b/system/modules/multicolumnwizard/html/js/multicolumnwizard_be_src.js
@@ -318,12 +318,13 @@ var MultiColumnWizard = new Class(
 
 /**
  * Operation "copy"
+ * @param The original event
  * @param The operation key
  * @param Element the icon element
  * @param Element the row
  * @param MCW instance
  */
-window.addEvent('mcw_button_click', function(key, operation, row, inst)
+window.addEvent('mcw_button_click', function(e, key, operation, row, inst)
 {
 	if (key != 'copy')
 		return;
@@ -382,12 +383,13 @@ window.addEvent('mcw_button_click', function(key, operation, row, inst)
 
 /**
  * Operation "delete" - click
+ * @param The original event
  * @param The operation key
  * @param Element the icon element
  * @param Element the row
  * @param MCW instance
  */
-window.addEvent('mcw_button_click', function(key, operation, row, inst)
+window.addEvent('mcw_button_click', function(e, key, operation, row, inst)
 {
 	if (key != 'delete')
 		return;
@@ -438,12 +440,13 @@ window.addEvent('mcw_button_click', function(key, operation, row, inst)
 
 /**
  * Operation "up" - click
+ * @param The original event
  * @param The operation key
  * @param Element the icon element
  * @param Element the row
  * @param MCW instance
  */
-window.addEvent('mcw_button_click', function(key, operation, row, inst)
+window.addEvent('mcw_button_click', function(e, key, operation, row, inst)
 {
 	if (key != 'up')
 		return;
@@ -473,12 +476,13 @@ window.addEvent('mcw_button_click', function(key, operation, row, inst)
 
 /**
  * Operation "down" - click
+ * @param The original event
  * @param The operation key
  * @param Element the icon element
  * @param Element the row
  * @param MCW instance
  */
-window.addEvent('mcw_button_click', function(key, operation, row, inst)
+window.addEvent('mcw_button_click', function(e, key, operation, row, inst)
 {
 	if (key != 'down')
 		return;


### PR DESCRIPTION
Hallo Jungs

Ich hab festgestellt, dass diese ganze Callback-Geschichte einfach nicht funktioniert.
Z.B. kommen die "+"-Buttons nicht mehr zum Vorschein, wenn ich per Delete-Button wieder unter den "maxCount" zurück falle und solche Spässe.

Ich hab das ganze mal komplett durch ein einfaches `window.fireEvent('mcw_button_click', [])` ersetzt. 
Die bestehenden Operations habe ich angepasst (evtl. mit minimalen Bugs noch beim minCount - hab ich nicht getestet) und jetzt funktionieren die Buttons soweit wie sie sollten.

Gibt dann halt ne Version 4, aber die ist meiner Meinung nach eh fällig...

Hoffe es hilft :-)
