### PR TITLE
introduce new eval property "rowClasses"

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizard.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizard.php
@@ -817,6 +817,12 @@ class MultiColumnWizard extends Widget implements uploadable
         // add class to enable easy updating of "name" attributes etc.
         $arrField['eval']['tl_class'] = trim($arrField['eval']['tl_class'] . ' mcwUpdateFields');
 
+        // if we have a row class, add that one aswell.
+        if (isset($arrField['eval']['rowClasses'][$intRow]))
+        {
+            $arrField['eval']['tl_class'] = trim($arrField['eval']['tl_class'] . ' ' . $arrField['eval']['rowClasses'][$intRow]);
+        }
+
         // load callback
         if (is_array($arrField['load_callback']))
         {


### PR DESCRIPTION
This PR introduces a new eval property "rowClasses" to allow predefined CSS classes per row.
We use this in MetaModels to highlight the fallback language row in the name and description MCW.
