### PR TITLE
Improved support for Contao 3.1

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizard.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizard.php
@@ -839,7 +839,12 @@ class MultiColumnWizard extends Widget implements uploadable
         $arrField['value']             = ($varValue !== '') ? $varValue : $arrField['default'];
         $arrField['eval']['tableless'] = true;
 
-        $objWidget = new $strClass($this->prepareForWidget($arrField, $arrField['name'], $arrField['value'], $arrField['strField'], $this->strTable));
+        if(version_compare(VERSION,'3.1', '<')){
+            $objWidget = new $strClass($this->prepareForWidget($arrField, $arrField['name'], $arrField['value'], $arrField['strField'], $this->strTable));
+        }
+        else{
+            $objWidget = new $strClass(\Widget::getAttributesFromDca($arrField, $arrField['name'], $arrField['value'], $arrField['strField'], $this->strTable, $this));
+        }
 
         $objWidget->strId         = $arrField['id'];
         $objWidget->storeValues   = true;


### PR DESCRIPTION
When using columnFields options_callback, it doesn´t pass an instance of MCW because new method getAttributesDca() is static and therefore expects DataContainer as additional parameter.
