### PR TITLE
Update htaccess to grant access on Apache 2.4

### DIFF
--- a/system/modules/multicolumnwizard/html/.htaccess
+++ b/system/modules/multicolumnwizard/html/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Allow from all
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>


### PR DESCRIPTION
With the release off Contao 3.0.6 the htaccess files were updated. Actually the mcw and any extension who used it would be broken on apache 2.4. 

More informations https://github.com/contao/core/issues/5032
