### PR TITLE
Fixed impossible unset of buttons

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizard.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizard.php
@@ -144,7 +144,7 @@ class MultiColumnWizard extends Widget implements uploadable
             case 'buttons':
                 if (is_array($varValue))
                 {
-                    $this->arrButtons = array_merge($this->arrButtons, array_intersect_key($varValue, $this->arrButtons));
+                    $this->arrButtons = $varValue;
                 }
                 break;
 


### PR DESCRIPTION
It is impossible to add your own button because the MCW always checks for `array_intersect_key()` (which doesn't make sense together with `array_merge()` anyway here because then the only option would be to change the icon) although the JavaScript was explicitly to be extended by any button you like :-)

I understand that `array_intersect_key()` makes sense if you want to make sure that the operations are limited to copy, up, down and delete because that's the only thing the MCW handles for you. But I think if a developer sets the buttons himself, it's also his responsibility to make sure those buttons work, isn't it? :-)

I only want to display the sorting buttons so I set

```
'buttons'           => array('up'=>'up.gif', 'down'=>'down.gif')
```

but the current code merges the passed in buttons with those that already exist --> so nothing happens :D
