### PR TITLE
Fixed hideHead

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizard.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizard.php
@@ -957,14 +957,18 @@ class MultiColumnWizard extends Widget implements uploadable
 
             if ($arrField['eval']['columnPos'])
             {
-                $arrHeaderItems[$arrField['eval']['columnPos']] = (key_exists($strKey, $arrHiddenHeader)) ? '<td class="invisible">' : '<td>' . '</td>';
+                $arrHeaderItems[$arrField['eval']['columnPos']] = '<td></td>';
             }
             else
             {
-                $arrHeaderItems[] = (key_exists($strKey, $arrHiddenHeader)) ? '<td class="invisible">' : '<td>';
-                $arrHeaderItems[] .= (is_array($arrField['label'])) ? $arrField['label'][0] : ($arrField['label'] != null ? $arrField['label'] : $strKey);
-                $arrHeaderItems[] .= ((is_array($arrField['label']) && $arrField['label'][1] != '') ? '<span title="' . $arrField['label'][1] . '"><sup>(?)</sup></span>' : '');
-                $arrHeaderItems[] .= '</td>';
+                $strHeaderItem = '<td>';
+
+                $strHeaderItem .= (key_exists($strKey, $arrHiddenHeader)) ? '<div class="invisible">' : '';
+                $strHeaderItem .= (is_array($arrField['label'])) ? $arrField['label'][0] : ($arrField['label'] != null ? $arrField['label'] : $strKey);
+                $strHeaderItem .= ((is_array($arrField['label']) && $arrField['label'][1] != '') ? '<span title="' . $arrField['label'][1] . '"><sup>(?)</sup></span>' : '');
+                $strHeaderItem .= (key_exists($strKey, $arrHiddenHeader)) ? '</div>' : '';
+
+                $arrHeaderItems[] = $strHeaderItem . '</td>';
             }
         }
 


### PR DESCRIPTION
hideHead was not working on fields with `input_field_callback`.

Also, do not use class invisible on table element.
Otherwise the table header columns would collapse, meaning the header
for column 3 will appear at position 2, if position 2 is invisible.
