### PR TITLE
Fix protected constructor issue.

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizardHelper.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizardHelper.php
@@ -19,6 +19,13 @@
  */
 class MultiColumnWizardHelper extends System
 {
+    /**
+     * Just here to make the constructor public.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
 
     public function addVersionToClass(&$objTemplate)
     {


### PR DESCRIPTION
The constructor of `\Contao\System` is protected. We have to override it to make the class instantiable from non system context.
