### PR TITLE
Fix for disappearing select-fields

### DIFF
--- a/system/modules/multicolumnwizard/html/js/multicolumnwizard_be_src.js
+++ b/system/modules/multicolumnwizard/html/js/multicolumnwizard_be_src.js
@@ -450,6 +450,7 @@ var MultiColumnWizard = new Class(
         {
             if (!($('top').hasClass('version_3-2') && build > 3)) {
                 $$('.styled_select').each(function(item, index){
+                    item.getNext().eliminate('div');
                     item.dispose();
                 });
                 Stylect.convertSelects();


### PR DESCRIPTION
If "add" pressed, various select (including core-selects like Version-Select at the top) disappearing because of still present data stored by stylect