### PR TITLE
fix version information leak (#184)

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizardHelper.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizardHelper.php
@@ -27,9 +27,19 @@ class MultiColumnWizardHelper extends System
         parent::__construct();
     }
 
-    public function addVersionToClass(&$objTemplate)
+    public function addScriptsAndStyles(&$objTemplate)
     {
-        $objTemplate->ua .= ' version_' . str_replace('.', '-', VERSION) . '-' . str_replace('.', '-', BUILD);
+        //do not allow version information to be leaked in the backend login and install tool (#184)
+        if ($objTemplate->getName() != 'be_login' && $objTemplate->getName() != 'be_install')
+        {
+            $GLOBALS['TL_JAVASCRIPT']['mcw'] = $GLOBALS['TL_CONFIG']['debugMode']
+                ? 'system/modules/multicolumnwizard/html/js/multicolumnwizard_be_src.js'
+                : 'system/modules/multicolumnwizard/html/js/multicolumnwizard_be.js';
+            $GLOBALS['TL_CSS']['mcw']        = $GLOBALS['TL_CONFIG']['debugMode']
+                ? 'system/modules/multicolumnwizard/html/css/multicolumnwizard_src.css'
+                : 'system/modules/multicolumnwizard/html/css/multicolumnwizard.css';
+            $objTemplate->ua .= ' version_' . str_replace('.', '-', VERSION) . '-' . str_replace('.', '-', BUILD);
+        }
     }
 
     public function supportModalSelector($strTable)

--- a/system/modules/multicolumnwizard/config/config.php
+++ b/system/modules/multicolumnwizard/config/config.php
@@ -39,11 +39,5 @@ $GLOBALS['TL_HOOKS']['executePostActions'][] = array('MultiColumnWizardHelper', 
 
 if (TL_MODE == 'BE')
 {
-    $GLOBALS['TL_JAVASCRIPT']['mcw'] = $GLOBALS['TL_CONFIG']['debugMode']
-            ? 'system/modules/multicolumnwizard/html/js/multicolumnwizard_be_src.js'
-            : 'system/modules/multicolumnwizard/html/js/multicolumnwizard_be.js';
-    $GLOBALS['TL_CSS']['mcw']        = $GLOBALS['TL_CONFIG']['debugMode']
-            ? 'system/modules/multicolumnwizard/html/css/multicolumnwizard_src.css'
-            : 'system/modules/multicolumnwizard/html/css/multicolumnwizard.css';
-    $GLOBALS['TL_HOOKS']['parseTemplate'][] = array('MultiColumnWizardHelper', 'addVersionToClass');
+    $GLOBALS['TL_HOOKS']['parseTemplate'][] = array('MultiColumnWizardHelper', 'addScriptsAndStyles');
 }


### PR DESCRIPTION
See #184 - the MultiColumnWizard extension causes a version information leak, since it always adds the Contao version to the `<body>` class in all Backend views, including the Install Tool and the Login screen.

Using `BE_USER_LOGGED_IN` did not work, since it will always be `false` at that point. Also `\BackendUser::getInstance()->authenticate()` will not work, because this would cause the Install Tool to not be accessible anymore (since `BackendUser::authenticate` always redirects to `contao/index.php` when the authentication fails).

Thus I have implemented it as I originally suggested.
