### PR TITLE
Correctly set the field and inputName attributes when creating DC

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizard.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizard.php
@@ -376,8 +376,9 @@ class MultiColumnWizard extends Widget implements uploadable
                     }
 
                     $dc            = new $dataContainer($this->strTable);
-                    $dc->field     = $objWidget->id;
-                    $dc->inputName = $objWidget->id;
+                    $dc->field     = $this->strField;
+                    $dc->inputName = $this->strField;
+                    $dc->strInputName = $this->strField;
 
                     foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['save_callback'] AS $callback)
                     {
@@ -611,8 +612,9 @@ class MultiColumnWizard extends Widget implements uploadable
                         }
 
                         $dc            = new $dataContainer($this->strTable);
-                        $dc->field     = $objWidget->id;
+                        $dc->field     = $strKey;
                         $dc->inputName = $objWidget->id;
+                        $dc->strInputName = $objWidget->id;
                         $dc->value     = $objWidget->value;
 
                         foreach ($arrField['wizard'] as $callback)


### PR DESCRIPTION
The attribute `inputName` is actually wrong, as it is only a getter and not a setter in `DataContainer` (see https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/DataContainer.php#L55). The value of the field can only be set by calling the actual variable name, as the setter allows for that.

Secondly, the `inputField` variable is intended to define the widget name without affecting the DCA field name. Therefore `$dc->field` should be set to the actual field, while `inputName` should be set to the generated name. DC_Table does the same in edit-multiple mode.

*This also fixes compatibility with the new dcaPicker in Contao 4.4*