### PR TITLE
Hotfix add closure load_callback

### DIFF
--- a/system/modules/multicolumnwizard/MultiColumnWizard.php
+++ b/system/modules/multicolumnwizard/MultiColumnWizard.php
@@ -964,6 +964,10 @@ class MultiColumnWizard extends Widget implements uploadable
                 $varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
             }
         }
+        elseif (is_callable($arrField['load_callback']))
+        {
+            $varValue = $arrField['load_callback']($varValue, $this);
+        }
 
         // Convert date formats into timestamps (check the eval setting first -> #3063)
         $rgxp = $arrField['eval']['rgxp'];


### PR DESCRIPTION
Hotfix add closure load_callback - https://github.com/menatwork/MultiColumnWizard/issues/151

```
            'mcw_text' => array
                (
                'label'         => &$GLOBALS['TL_LANG'][$strTblName]['mcw_text'],
                'exclude'       => true,
                'inputType'     => 'text',
                'eval'          => array('style'=>'width:150px'),
                'load_callback' => function($varValue, $dc) 
                    {
                        return 2;
                    }
                ),
```
![shot369](https://user-images.githubusercontent.com/1045318/31292822-2328cef4-aad5-11e7-90e3-919df25e42c2.jpg)

