### PR TITLE
Fix #239 - make dc-general optional again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,7 @@
 	},
 	"require": {
 		"contao/core-bundle":"~3.2 || ~4.1",
-		"contao-community-alliance/composer-plugin":"~2.4 || ~3.0",
-		"contao-community-alliance/dc-general": "^2.0@beta"
+		"contao-community-alliance/composer-plugin":"~2.4 || ~3.0"
 	},
 	"autoload":{
 		"classmap":["system/"],

--- a/system/modules/multicolumnwizard/config/event_listeners.php
+++ b/system/modules/multicolumnwizard/config/event_listeners.php
@@ -12,12 +12,16 @@
 use ContaoCommunityAlliance\DcGeneral\Factory\Event\BuildDataDefinitionEvent;
 use MultiColumnWizard\DcGeneral\UpdateDataDefinition;
 
-return array
-(
-    BuildDataDefinitionEvent::NAME => array(
-        array(
-            array(new UpdateDataDefinition(), 'addMcwFields'),
-            UpdateDataDefinition::PRIORITY
+if (class_exists(BuildDataDefinitionEvent::class)) {
+    return array
+    (
+        BuildDataDefinitionEvent::NAME => array(
+            array(
+                array(new UpdateDataDefinition(), 'addMcwFields'),
+                UpdateDataDefinition::PRIORITY
+            )
         )
-    )
-);
+    );
+}
+
+return array();


### PR DESCRIPTION
This removes the hard dependency on dc-general by conditionally
registering the event listener.